### PR TITLE
Fix to compile in MS Visual C++

### DIFF
--- a/include/tap++/tap++.h
+++ b/include/tap++/tap++.h
@@ -7,6 +7,10 @@
 #include <functional>
 #include <limits>
 
+#ifdef _MSC_VER
+#pragma warning( disable : 4290 ) // MSVC: https://msdn.microsoft.com/en-us/library/sa28fef8.aspx
+#endif
+
 namespace TAP {
 	namespace details {
 		struct skip_all_type {};
@@ -178,11 +182,11 @@ namespace TAP {
   }
 
 	template<> inline bool is<float, double>(const float& left, const double& right, const std::string& message) {
-  	return is(left, right, message, nearly_equal<float>());
+  	return is(left, right, message, nearly_equal<double>());
   }
 
 	template<> inline bool is<double, float>(const double& left, const float& right, const std::string& message) {
-  	return is(left, right, message, nearly_equal<float>());
+  	return is(left, right, message, nearly_equal<double>());
   }
 
 	template<> inline bool is<double, double>(const double& left, const double& right, const std::string& message) {
@@ -194,11 +198,11 @@ namespace TAP {
   }
 
 	template<> inline bool isnt<float, double>(const float& left, const double& right, const std::string& message) {
-  	return isnt(left, right, message, nearly_equal<float>());
+  	return isnt(left, right, message, nearly_equal<double>());
   }
 
 	template<> inline bool isnt<double, float>(const double& left, const float& right, const std::string& message) {
-  	return isnt(left, right, message, nearly_equal<float>());
+  	return isnt(left, right, message, nearly_equal<double>());
   }
 
 	template<> inline bool isnt<double, double>(const double& left, const double& right, const std::string& message) {

--- a/src/tap++.cpp
+++ b/src/tap++.cpp
@@ -3,6 +3,7 @@
 #include <stack>
 #include <sstream>
 #include <cstdlib>
+#include <algorithm>
 
 namespace TAP {
   double EPSILON = 1.e-4;


### PR DESCRIPTION
1. # include <algorithm>
   
   Needed to stop error C2039: 'min': is not a member of 'std'
2. # pragma warning( disable : 4290 )
   
   Needed to stop warning C4290: C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
   See https://msdn.microsoft.com/en-us/library/sa28fef8.aspx
3. nearly_equal<double> instead of nearly_equal<float> if any of the arguments is double
   Needed to stop warning C4244: 'argument': conversion from 'const double' to 'const float', possible loss of data
