### PR TITLE
Fix return value in run_tests.pl

### DIFF
--- a/run_tests.pl
+++ b/run_tests.pl
@@ -16,4 +16,4 @@ my $harness = TAP::Harness->new( {
     color => 1,
 });
 
-$harness->runtests(@ARGV);
+$harness->runtests(@ARGV)->all_passed or exit 1;


### PR DESCRIPTION
run_tests.pl now exits with exit value of 0 if all tests pass and 1
otherwise.

This is required to signal test failure to the build environment, e.g.
makefile.
