### PR TITLE
clang++ complains 'exception::what' hides overloaded virtual function

### DIFF
--- a/t/00-sanity.cpp
+++ b/t/00-sanity.cpp
@@ -11,7 +11,7 @@ class exception : public std::exception {
 public:
     exception(const std::string& _message) : message(_message) {
     }
-    const char* what() {
+    virtual const char* what() const noexcept {
         return message.c_str();
     }
     ~exception() throw() {

--- a/t/00-sanity.cpp
+++ b/t/00-sanity.cpp
@@ -11,7 +11,7 @@ class exception : public std::exception {
 public:
     exception(const std::string& _message) : message(_message) {
     }
-    virtual const char* what() const noexcept {
+    virtual const char* what() const throw() {
         return message.c_str();
     }
     ~exception() throw() {


### PR DESCRIPTION
Change what() signature to the same as the base function
virtual const char\* what() const noexcept
